### PR TITLE
fixed an issue where Error was ignoring verbosity

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -47,6 +47,9 @@ func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
 // while the err field should be used to attach the actual error that
 // triggered this log line, if present.
 func (l *Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if !l.Enabled() {
+		return
+	}
 	if err == nil {
 		l.base.Error(nil, msg, keysAndValues...)
 		return


### PR DESCRIPTION
Problem:

`log.V(3).Error(err, "something")` will be logged no matter what the verbosity is set to