### PR TITLE
change log "cause" key to "error"

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -13,7 +13,7 @@ import (
 
 // Keys used to log specific builtin fields
 const (
-	ErrorKey     = "cause"
+	ErrorKey     = "error"
 	MessageKey   = "message"
 	TimeStampKey = "ts"
 	ComponentKey = "component"

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -104,7 +104,7 @@ func TestLogger_Error_nested_error(t *testing.T) {
 			log.ErrorKey: map[string]interface{}{
 				"key": "value",
 				"msg": kverrors.Message(err),
-				log.ErrorKey: map[string]interface{}{
+				kverrors.CauseKey: map[string]interface{}{
 					"order": 1,
 					"msg":   kverrors.Message(err1),
 				},


### PR DESCRIPTION
This was inadvertently added because kverrors have a "cause" key which contains the wrapped error. The log's root error key should be "error" to indicate that there was an error and wrapped errors should be the "cause" key. 