### PR TITLE
Remove AppendMap from log.Info()

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -118,7 +118,7 @@ func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
 	if !l.Enabled() {
 		return
 	}
-	l.log(msg, kv.AppendMap(l.context, kv.ToMap(keysAndValues...)))
+	l.log(msg, kv.ToMap(keysAndValues...))
 }
 
 // Error logs an error, with the given message and key/value pairs as context.


### PR DESCRIPTION
the following log statements
```
log.Info("this is a log message", "key1", "value1")      
log.Info("this is a log message", "key2", "value2")      
log.Info("this is a log message", "key3", "value3")      
log.Info("this is a log message", "key4", "value4")      
log.Info("this is a log message", "key5", "value5")
log.Info("this is a log message", "key1", "changed value")
```

produces these logs
```
{"component":"test","filename":"/home/vimalkum/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/kafka/forward_to_kafka_test.go","key1":"value1","message":"this is a log message","ts":"2020-11-27T14:23:48.415088395Z"}
{"component":"test","filename":"/home/vimalkum/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/kafka/forward_to_kafka_test.go","key1":"value1","key2":"value2","message":"this is a log message","ts":"2020-11-27T14:23:48.415111063Z"}
{"component":"test","filename":"/home/vimalkum/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/kafka/forward_to_kafka_test.go","key1":"value1","key2":"value2","key3":"value3","message":"this is a log message","ts":"2020-11-27T14:23:48.415125402Z"}
{"component":"test","filename":"/home/vimalkum/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/kafka/forward_to_kafka_test.go","key1":"value1","key2":"value2","key3":"value3","key4":"value4","message":"this is a log message","ts":"2020-11-27T14:23:48.415139781Z"}
{"component":"test","filename":"/home/vimalkum/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/kafka/forward_to_kafka_test.go","key1":"value1","key2":"value2","key3":"value3","key4":"value4","key5":"value5","message":"this is a log message","ts":"2020-11-27T14:23:48.415158585Z"}
{"component":"test","filename":"/home/vimalkum/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/kafka/forward_to_kafka_test.go","key1":"changed value","key2":"value2","key3":"value3","key4":"value4","key5":"value5","message":"this is a log message","ts":"2020-11-27T14:23:48.415172626Z"}
```
The context keeps accumulating keys, and after some time, the logs become really incomprehensible because it accumulates lots of keys, and it makes logs really hard to match with code.

