### PR TITLE
Fix #13: accidental context changes and error overwrite

### DIFF
--- a/internal/kv/kv.go
+++ b/internal/kv/kv.go
@@ -20,14 +20,6 @@ func ToMap(keysAndValues ...interface{}) map[string]interface{} {
 	return kve
 }
 
-// AppendMap appends one map to another
-func AppendMap(a, b map[string]interface{}) map[string]interface{} {
-	for k, v := range b {
-		a[k] = v
-	}
-	return a
-}
-
 // FromMap converts a map to a key/value slice
 func FromMap(m map[string]interface{}) []interface{} {
 	res := make([]interface{}, 0, len(m)*2)

--- a/kverrors/kverrors.go
+++ b/kverrors/kverrors.go
@@ -16,11 +16,8 @@ const (
 
 // New creates a new KVError with keys and values
 func New(msg string, keysAndValues ...interface{}) error {
-	return &KVError{
-		kv: kv.AppendMap(map[string]interface{}{
-			MessageKey: msg,
-		}, kv.ToMap(keysAndValues...)),
-	}
+	keysAndValues = append([]interface{}{MessageKey, msg}, keysAndValues...)
+	return &KVError{kv: kv.ToMap(keysAndValues...)}
 }
 
 // NewCtx creates a new error with Context

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -91,29 +91,24 @@ func TestWithValues(t *testing.T) {
 	log.UseLogger(logger)
 
 	msg := t.Name()
-	ctx := map[string]interface{}{
-		"left":  "right",
-		"hello": "world",
-	}
-
-	ll := log.WithValues(kv.FromMap(ctx)...)
-
-	assertions := func(t *testing.T) {
-		logs := obs.TakeAll()
-		if assert.Len(t, logs, 1) {
-			assert.EqualValues(t, msg, logs[0].Message)
-			assert.EqualValues(t, ctx, logs[0].Context)
-		}
-	}
+	ll := log.WithValues("hello", "world")
 
 	t.Run("Error", func(t *testing.T) {
 		ll.Error(errors.New("fail boat"), msg)
-		assertions(t)
+		logs := obs.TakeAll()
+		require.Len(t, logs, 1)
+		assert.EqualValues(t, msg, logs[0].Message)
+		assert.EqualValues(t, kv.ToMap("hello", "world"), logs[0].Context)
 	})
 
 	t.Run("Info", func(t *testing.T) {
-		ll.Info(msg, kv.FromMap(ctx)...)
-		assertions(t)
+		ll.Info(msg, "a", "b")
+		ll.Info(msg, "c", "d")
+		logs := obs.TakeAll()
+		require.Len(t, logs, 2)
+		assert.EqualValues(t, msg, logs[0].Message)
+		assert.EqualValues(t, kv.ToMap("a", "b", "hello", "world"), logs[0].Context)
+		assert.EqualValues(t, kv.ToMap("c", "d", "hello", "world"), logs[1].Context)
 	})
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -62,11 +62,29 @@ func NewLogger(name string, w io.Writer, v Verbosity, e Encoder, keysAndValues .
 	}
 }
 
+// combine creates a new map combining context and keysAndValues.
+func combine(context map[string]interface{}, keysAndValues ...interface{}) map[string]interface{} {
+	nc := make(map[string]interface{}, len(context)+len(keysAndValues)/2)
+	for k, v := range context {
+		nc[k] = v
+	}
+	for i := 0; i < len(keysAndValues); i += 2 {
+		if i+1 < len(keysAndValues) {
+			key, ok := keysAndValues[i].(string) // It should be a string.
+			if !ok {                             // But this is not the place to panic
+				key = fmt.Sprintf("%s", keysAndValues[i]) // So use this expensive conversion instead.
+			}
+			nc[key] = keysAndValues[i+1]
+		}
+	}
+	return nc
+}
+
 // withValues clones the logger and appends keysAndValues
 // but returns a struct instead of the logr.Logger interface
 func (l *Logger) withValues(keysAndValues ...interface{}) *Logger {
 	ll := NewLogger(l.name, l.output, l.verbosity, l.encoder)
-	ll.context = kv.AppendMap(kv.ToMap(keysAndValues...), l.context)
+	ll.context = combine(l.context, keysAndValues...)
 	return ll
 }
 
@@ -94,16 +112,15 @@ func (l *Logger) Enabled() bool {
 // log will log the message. It DOES NOT check Enabled() first so that should
 // be checked by it's callers
 func (l *Logger) log(msg string, context map[string]interface{}) {
-	m := kv.AppendMap(context, map[string]interface{}{
-		MessageKey:   msg,
-		TimeStampKey: TimestampFunc(),
-		ComponentKey: l.name,
-		LevelKey:     l.verbosity.String(),
-	})
+	m := combine(context,
+		MessageKey, msg,
+		TimeStampKey, TimestampFunc(),
+		ComponentKey, l.name,
+		LevelKey, l.verbosity.String())
 	err := l.encoder.Encode(l.output, m)
 	if err != nil {
 		// expand first so we can quote later
-		orig := fmt.Sprintf("%#v", context)
+		orig := fmt.Sprintf("%#v", m)
 		_, _ = fmt.Fprintf(l.output, `{"message","failed to encode message", "encoder":"%T","log":%q,"cause":%q}`, l.encoder, orig, err)
 	}
 }
@@ -118,7 +135,7 @@ func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
 	if !l.Enabled() {
 		return
 	}
-	l.log(msg, kv.AppendMap(l.context, kv.ToMap(keysAndValues...)))
+	l.log(msg, combine(l.context, keysAndValues...))
 }
 
 // Error logs an error, with the given message and key/value pairs as context.


### PR DESCRIPTION
kv.AppendMap was modifying its first parameter, causing logger to append log entry values to the logger context.

Updated TestWithValues to log 2 messages with different values to demonstrate bug.

Deleted kv.AppendMap(), replaced in logger with private func combine() to create a new combined context maps.

Fixed tests: observedEntry.ToMap(), parseEntry both modified their map parameter.  parseEntry was over-writting the error in the log message.

/cc @blockloop