### PR TITLE
Use singleton for DefaultLogger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -14,11 +14,13 @@ var (
 	ErrUnknownSinkType = kverrors.New("unknown log sink type")
 
 	defaultOutput = os.Stdout
+
+	defaultLogger = logr.New(NewLogSink("", defaultOutput, 0, JSONEncoder{}))
 )
 
 // DefaultLogger creates a logger without any key value pairs
 func DefaultLogger() logr.Logger {
-	return logr.New(NewLogSink("", defaultOutput, 0, JSONEncoder{}))
+	return defaultLogger
 }
 
 // NewLogger creates a logger with the provided key value pairs


### PR DESCRIPTION
The 1.1.0 update introduced the `log.DefaultLogger()` function as a possible migration path for the previous `log.V(), log.Info(), log.Error()` functions. Currently the implementation creates a new logger on each invocation which seems wasteful. This PR changes the code so that only one `defaultLogger` is created in the package which is returned by the `DefaultLogger()` function.