### PR TITLE
Add static logger for easier migration of v1 code

### DIFF
--- a/log/static.go
+++ b/log/static.go
@@ -1,0 +1,56 @@
+package log
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+var (
+	lock   sync.RWMutex
+	logger = NewLogger("uninitialized")
+)
+
+// SetLogger sets the static logger instance.
+func SetLogger(replacement logr.Logger) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	logger = replacement
+}
+
+// WithName returns a logger with name added to the component.
+// This uses the static logger instance.
+func WithName(name string) logr.Logger {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	return logger.WithName(name)
+}
+
+// V returns a logger with the verbosity set to level.
+// This uses the static logger instance.
+func V(level int) logr.Logger {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	return logger.V(level)
+}
+
+// Info logs an informational message with optional key-value pairs.
+// This uses the static logger instance.
+func Info(msg string, keysAndValues ...interface{}) {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	logger.Info(msg, keysAndValues...)
+}
+
+// Error logs an error message with optional key-value pairs.
+// This uses the static logger instance.
+func Error(err error, msg string, keysAndValues ...interface{}) {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	logger.Error(err, msg, keysAndValues...)
+}

--- a/log/static/static.go
+++ b/log/static/static.go
@@ -1,14 +1,20 @@
-package log
+// Package static provides a simple static logger implementation for easy migration of existing pre-v2 code.
+//
+// The package is usually imported aliased as "log" to be compatible with the v1 approach.
+//
+// The static logger instance needs to be initialized during startup of the application using SetLogger.
+package static
 
 import (
 	"sync"
 
+	"github.com/ViaQ/logerr/v2/log"
 	"github.com/go-logr/logr"
 )
 
 var (
 	lock   sync.RWMutex
-	logger = NewLogger("uninitialized")
+	logger = log.NewLogger("uninitialized")
 )
 
 // SetLogger sets the static logger instance.


### PR DESCRIPTION
This PR reintroduces the concept of a static logger to `logerr`, because we have now seen that migrating a whole code-base to the new approach in a single step might not be desirable.

An idea that floated around my head while adding this was whether it might make sense to have this in a separate package, so that it is clear that having a static logger is a different concept from what the rest of the package provides. This should only impact packages that need to initialize a logger (like main or testing packages), users of the static logger would alias-import the package as `log`.

/cc @periklis 

