### PR TITLE
NO-JIRA: Add static.Logger() so new code can use non-static patterns.

### DIFF
--- a/log/static/static.go
+++ b/log/static/static.go
@@ -25,6 +25,13 @@ func SetLogger(replacement logr.Logger) {
 	logger = replacement
 }
 
+// Logger returns the static logger instance.
+func Logger() logr.Logger {
+	lock.RLock()
+	defer lock.RUnlock()
+	return logger
+}
+
 // WithName returns a logger with name added to the component.
 // This uses the static logger instance.
 func WithName(name string) logr.Logger {


### PR DESCRIPTION
Add static.Logger() so that the static logger can be passed as an argument. 
Allows old code using the static log pattern to be extended with new code using log argument passing.